### PR TITLE
Favor using non deprecated build scan configuration API

### DIFF
--- a/samples/code/build-scan-from-build-script/build.gradle
+++ b/samples/code/build-scan-from-build-script/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
 // tag::build-scan-dsl[]
 buildScan {
-    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
-    licenseAgree = 'yes'
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 // end::build-scan-dsl[]
 

--- a/samples/code/build-scan-from-init-script/buildScan.gradle
+++ b/samples/code/build-scan-from-init-script/buildScan.gradle
@@ -12,7 +12,7 @@ rootProject {
     apply plugin: com.gradle.scan.plugin.BuildScanPlugin
 
     buildScan {
-        licenseAgreementUrl = 'https://gradle.com/terms-of-service'
-        licenseAgree = 'yes'
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
     }
 }

--- a/samples/code/build-scan-from-init-script/buildScan.gradle
+++ b/samples/code/build-scan-from-init-script/buildScan.gradle
@@ -1,6 +1,6 @@
 initscript {
     repositories {
-        maven { url 'https://plugins.gradle.org/m2' }
+        gradlePluginPortal()
     }
 
     dependencies {


### PR DESCRIPTION
and `gradlePluginPortal()` instead of the repository URL.