### PR TITLE
Let this guide display both Groovy and Kotlin samples

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -31,11 +31,17 @@ This mechanism makes it very easy to generate ad-hoc, one-off build scans withou
 
 == Enable build scans on all builds of your project
 
-Add a `plugins` block to the `build.gradle` file with the following contents:
+Add a `plugins` block to the root project build script file with the following contents:
 
-[source, groovy]
+[source.multi-language-sample, groovy]
+.build.gradle
 ----
 include::{samplescodedir}/build-scan-from-build-script/build.gradle[tags=build-scan-plugin-plugins-apply]
+----
+[source.multi-language-sample, kotlin]
+.build.gradle.kts
+----
+include::{samplescodedir}/build-scan-from-build-script/build.gradle.kts[tags=build-scan-plugin-plugins-apply]
 ----
 <1> Use latest plugin version which can be found on the https://plugins.gradle.org/plugin/com.gradle.build-scan[Gradle Plugin Portal].
 
@@ -46,9 +52,15 @@ If you already have a `plugins` block, always put the build scan plugin first. A
 In order to publish build scans to https://scans.gradle.com, you need to accept the license agreement.
 This can be done ad-hoc via the command line when publishing, but can also be specified in your Gradle build file, by adding the following section:
 
-[source,groovy]
+[source.multi-language-sample,groovy]
+.build.gradle
 ----
 include::{samplescodedir}/build-scan-from-build-script/build.gradle[tags=build-scan-dsl]
+----
+[source.multi-language-sample,kotlin]
+.build.gradle.kts
+----
+include::{samplescodedir}/build-scan-from-build-script/build.gradle.kts[tags=build-scan-dsl]
 ----
 
 The `buildScan` block allows you to configure the plugin. Here you are setting two properties necessary to accept the license agreement.
@@ -82,11 +94,17 @@ You can now explore all the information contained in the build scan, including t
 
 == Enable build scans for all builds (optional)
 
-You can avoid having to add the plugin and license agreement to every build by using a Gradle init script. Create a file called `buildScan.gradle` in the directory `~/.gradle/init.d` (where the tilde represents your home directory) with the following contents:
+You can avoid having to add the plugin and license agreement to every build by using a Gradle init script. Create a file in the directory `~/.gradle/init.d` (where the tilde represents your home directory) with the following contents:
 
-[source, groovy]
+[source.multi-language-sample, groovy]
+.buildScan.gradle
 ----
 include::{samplescodedir}/build-scan-from-init-script/buildScan.gradle[]
+----
+[source.multi-language-sample, kotlin]
+.buildScan.init.gradle.kts
+----
+include::{samplescodedir}/build-scan-from-init-script/buildScan.init.gradle.kts[]
 ----
 
 The init script downloads the build scan plugin if necessary and applies it to every project, and accepts the license agreement. Now you can use the `--scan` flag on any build on your system.

--- a/samples/code/build-scan-from-build-script/build.gradle.kts
+++ b/samples/code/build-scan-from-build-script/build.gradle.kts
@@ -1,0 +1,14 @@
+// tag::build-scan-plugin-plugins-apply[]
+plugins {
+    id("com.gradle.build-scan") version "1.13.1" // <1>
+}
+// end::build-scan-plugin-plugins-apply[]
+
+// tag::build-scan-dsl[]
+buildScan {
+    setTermsOfServiceUrl("https://gradle.com/terms-of-service")
+    setTermsOfServiceAgree("yes")
+}
+// end::build-scan-dsl[]
+
+apply(plugin = "base")

--- a/samples/code/build-scan-from-init-script/build.gradle.kts
+++ b/samples/code/build-scan-from-init-script/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    base
+}

--- a/samples/code/build-scan-from-init-script/buildScan.init.gradle.kts
+++ b/samples/code/build-scan-from-init-script/buildScan.init.gradle.kts
@@ -1,0 +1,18 @@
+initscript {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    dependencies {
+        classpath("com.gradle:build-scan-plugin:1.13.1")
+    }
+}
+
+rootProject {
+    apply<com.gradle.scan.plugin.BuildScanPlugin>()
+
+    configure<com.gradle.scan.plugin.BuildScanExtension> {
+        setTermsOfServiceUrl("https://gradle.com/terms-of-service")
+        setTermsOfServiceAgree("yes")
+    }
+}

--- a/src/test/groovy/org/gradle/guides/SamplesFunctionalTest.groovy
+++ b/src/test/groovy/org/gradle/guides/SamplesFunctionalTest.groovy
@@ -25,27 +25,39 @@ class SamplesFunctionalTest extends AbstractSamplesFunctionalTest {
         result.output.contains(BUILD_SCAN_PUBLISHED_MESSAGE)
     }
 
-    def "can create build scan from build script"() {
+    @Unroll
+    def "can create build scan from #lang build script"() {
         given:
         copySampleCode('build-scan-from-build-script')
 
         when:
-        def result = succeeds('build', '--scan')
+        def result = succeeds('-b', buildScriptFilename, 'build', '--scan')
 
         then:
         result.task(':build').outcome == UP_TO_DATE
         result.output.contains(BUILD_SCAN_PUBLISHED_MESSAGE)
+
+        where:
+        lang     | buildScriptFilename
+        'Groovy' | 'build.gradle'
+        'Kotlin' | 'build.gradle.kts'
     }
 
-    def "can create build scan from init script"() {
+    @Unroll
+    def "can create build scan from #lang init script"() {
         given:
         copySampleCode('build-scan-from-init-script')
 
         when:
-        def result = succeeds('build', '--scan', '-I', 'buildScan.gradle')
+        def result = succeeds('-b', buildScriptFilename, 'build', '--scan', '-I', initScriptFilename)
 
         then:
         result.task(':build').outcome == UP_TO_DATE
         result.output.contains(BUILD_SCAN_PUBLISHED_MESSAGE)
+
+        where:
+        lang     | buildScriptFilename | initScriptFilename
+        'Groovy' | 'build.gradle'      | 'buildScan.gradle'
+        'Kotlin' | 'build.gradle.kts'  | 'buildScan.init.gradle.kts'
     }
 }


### PR DESCRIPTION
The Gradle Kotlin DSL samples use non-deprecated build scan configuration API and prefer `gradlePluginPortal()` over the repository URL as https://github.com/gradle-guides/creating-build-scans/pull/11 does for the Groovy samples.